### PR TITLE
Make debug step defs use Specr.client, not @client

### DIFF
--- a/lib/specr/step_definitions/debugging_steps.rb
+++ b/lib/specr/step_definitions/debugging_steps.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 Then(/^debug$/) do
-  Specr.logger.debug "HTTP status code: #{@client.last_code}"
-  Specr.logger.debug "HTTP body: #{@client.last_body}"
-  Specr.logger.debug "Storage: #{@client.storage}"
+  Specr.logger.debug "HTTP status code: #{Specr.client.last_code}"
+  Specr.logger.debug "HTTP body: #{Specr.client.last_body}"
+  Specr.logger.debug "Storage: #{Specr.client.storage}"
 end
 
 When(/^debugging is enabled$/) do


### PR DESCRIPTION
The code in `lib/specr/step_definitions/debugging_steps.rb` references `@client`, which doesn't exist. I'm guessing I'm seeing cobwebs from an earlier version.

Changing each `@client` to `Specr.client` seems to resolve the issue.