### PR TITLE
Include error_codes.json content in specification.json

### DIFF
--- a/lib/specr/extracer.rb
+++ b/lib/specr/extracer.rb
@@ -53,6 +53,7 @@ module Specr
         resources_create: @resources_create,
         resources_update: @resources_update,
         forms: load_forms,
+        errors: load_error_codes,
         schemas: load_schemas
       }
       File.open(file, 'w') { |f| f.write(JSON.pretty_generate(json)) }
@@ -102,6 +103,10 @@ module Specr
 
     def load_forms
       JSON.parse(File.read('forms.json'))
+    end
+
+    def load_error_codes
+      JSON.parse(File.read('error_codes.json'))
     end
   end
 end


### PR DESCRIPTION
This version assumes that `error_codes.json` exists in the Kessel root directory, alongside `endpoints.json` and `forms.json`.

The idea is "_get it working, **then** get it right_". As for _getting it right_, we'll probably eventually change this to pull the error codes directly from the Kessel repo, rather than requiring the user to manually copy the file into this repo.