### PR TITLE
Include filters.json content in specification.json

### DIFF
--- a/lib/specr/extracer.rb
+++ b/lib/specr/extracer.rb
@@ -53,6 +53,7 @@ module Specr
         resources_create: @resources_create,
         resources_update: @resources_update,
         forms: load_forms,
+        filterable_attributes: load_filterable_attributes,
         schemas: load_schemas
       }
       File.open(file, 'w') { |f| f.write(JSON.pretty_generate(json)) }
@@ -102,6 +103,10 @@ module Specr
 
     def load_forms
       JSON.parse(File.read('forms.json'))
+    end
+
+    def load_filterable_attributes
+      JSON.parse(File.read('filters.json'))
     end
   end
 end


### PR DESCRIPTION
A new Blacksmith rake task produces JSON describing the filterable attributes for each Launch asset type. This commit causes Kessel to copy that data into its output.