### PR TITLE
Record error responses if explicitly requested

### DIFF
--- a/lib/specr/extracer.rb
+++ b/lib/specr/extracer.rb
@@ -26,8 +26,10 @@ module Specr
         request: request,
         response: opts.fetch(:response_body),
         response_code: opts.fetch(:response_code),
+        response_html: opts[:response_html],
         response_message: opts.fetch(:response_message)
       }
+      scenario.delete(:response_html) unless scenario[:response_html]
       @scenarios << scenario
       return unless scenario[:response_body]
       # TODO: make these extract from arrays when those are being used

--- a/lib/specr/step_definitions/http_steps.rb
+++ b/lib/specr/step_definitions/http_steps.rb
@@ -45,3 +45,7 @@ end
 Then(/^there should be no response body$/) do
   assert_nil Specr.client.last_body
 end
+
+Then(/^I expect an error$/) do
+  Specr.client.record_even_on_error = true
+end


### PR DESCRIPTION
Sometimes its useful to capture the response, even when there's an error.

This PR adds a flag that causes specr to record the next response even if the request produces an error. The flag can be enabled for the next request by including this Cucumber:

```cucumber
Then I expect an error
```