### PR TITLE
added support for Specr.client.storage_global

### DIFF
--- a/lib/specr/tiny_client.rb
+++ b/lib/specr/tiny_client.rb
@@ -4,7 +4,7 @@ require 'pp'
 module Specr
   class TinyClient
     attr_accessor :headers, :current_scenario
-    attr_reader :extracer, :responses, :storage
+    attr_reader :extracer, :responses, :storage, :storage_global
 
     def initialize(extracer)
       @extracer = extracer
@@ -12,9 +12,11 @@ module Specr
       @headers = Specr.configuration.default_headers
       @responses = []
       @storage = {}
+      @storage_global = {}
     end
 
-    def clear_storage
+    def clear_storage(global=false)
+      @storage_global = {} if global
       @storage = {}
     end
 


### PR DESCRIPTION
Support for a global storage option that is not clear with every scenario.
Can also be cleared manually by calling Specr.client.clear_storage(true)

The param to clear_storage could be done differently, open to suggestions.