### PR TITLE
Update Get to accept a body

### DIFF
--- a/lib/specr/tiny_client.rb
+++ b/lib/specr/tiny_client.rb
@@ -95,8 +95,8 @@ module Specr
       request(:patch, endpoint, opts.merge!(body: body))
     end
 
-    def get(endpoint)
-      request(:get, endpoint)
+    def get(endpoint, body = nil, opts = {})
+      request(:get, endpoint, opts.merge!(body: body))
     end
 
     def delete(endpoint, body = nil, opts = {})


### PR DESCRIPTION
In order to support the new /search functionality we need to accept a GET request with an optional body