### PR TITLE
Hydrate multipart file parameter

### DIFF
--- a/lib/specr/step_definitions/http_steps.rb
+++ b/lib/specr/step_definitions/http_steps.rb
@@ -13,12 +13,12 @@ end
 
 When(/^I (POST|PATCH) to (\/\S*?) with the file "(.*?)" as "(.*?)"$/) do |verb, url, file, file_field|
   Specr.client.send("#{verb.downcase}_multipart",
-                    Specr.client.hydrater(url), file, file_field, nil)
+                    Specr.client.hydrater(url), Specr.client.hydrater(file), file_field, nil)
 end
 
 When(/^I (POST|PATCH) to (\/\S*?) with the "(.*?)" file as "(.*?)" and the body:$/) do |verb, url, file, file_field, body|
   Specr.client.send("#{verb.downcase}_multipart",
-                    Specr.client.hydrater(url), file, file_field, body)
+                    Specr.client.hydrater(url), Specr.client.hydrater(file), file_field, body)
 end
 
 When(/^I (\w+) to the "(.*?)" link with the body:$/) do |verb, keys, body|


### PR DESCRIPTION
This will make it possible for the step `When I POST to /packages with the file ":file_name" as "package"` to read `:file_name` from `Specr.client.storage['file_name']`.